### PR TITLE
UMD build

### DIFF
--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -12,10 +12,10 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build",
+    "build": "tsdx build --format cjs,esm,umd --name ionio",
     "test": "tsdx test",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
+    "prepare": "tsdx build --format cjs,esm,umd --name ionio",
     "size": "size-limit",
     "analyze": "size-limit --why"
   },

--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -230,7 +230,7 @@ export class Transaction implements TransactionInterface {
           'if one confidential input is spent, at least one of the outputs must be blinded'
         );
 
-      this.psbt.blindOutputsByIndex(
+      await this.psbt.blindOutputsByIndex(
         Psbt.ECCKeysGenerator(this.ecclib),
         this.inputBlindingData,
         this.outputBlindingPubKeys


### PR DESCRIPTION
- hotfix: await blindOutputsByIndex in unlock()
- umd build support
