### PR TITLE
Support passing buffer-like arguments as 0x prefixed strings

### DIFF
--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "ldk": "^0.5.1",
+    "ldk": "^0.5.2",
     "liquidjs-lib": "git+https://github.com/louisinger/liquidjs-lib.git#psbt-taproot-support"
   },
   "jest": {

--- a/packages/ionio/src/Argument.ts
+++ b/packages/ionio/src/Argument.ts
@@ -96,7 +96,7 @@ export function encodeArgument(
       if (typeof value === 'string' && value.startsWith('0x')) {
         value = Buffer.from(value.slice(2), 'hex');
       }
-      
+
       if (!Buffer.isBuffer(value)) {
         throw new TypeError(typeof value, typeStr);
       }

--- a/packages/ionio/src/Argument.ts
+++ b/packages/ionio/src/Argument.ts
@@ -22,9 +22,14 @@ export function encodeArgument(
 ): Buffer | Signer {
   switch (typeStr) {
     case PrimitiveType.Bytes:
+      if (typeof value === 'string' && value.startsWith('0x')) {
+        value = Buffer.from(value.slice(2), 'hex');
+      }
+
       if (!Buffer.isBuffer(value)) {
         throw new TypeError(typeof value, typeStr);
       }
+
       return value;
 
     case PrimitiveType.Number:
@@ -34,6 +39,10 @@ export function encodeArgument(
       return script.number.encode(value);
 
     case PrimitiveType.XOnlyPublicKey:
+      if (typeof value === 'string' && value.startsWith('0x')) {
+        value = Buffer.from(value.slice(2), 'hex');
+      }
+
       if (!Buffer.isBuffer(value)) {
         throw new TypeError(typeof value, typeStr);
       }
@@ -43,6 +52,10 @@ export function encodeArgument(
       return value;
 
     case PrimitiveType.PublicKey:
+      if (typeof value === 'string' && value.startsWith('0x')) {
+        value = Buffer.from(value.slice(2), 'hex');
+      }
+
       if (!Buffer.isBuffer(value)) {
         throw new TypeError(typeof value, typeStr);
       }
@@ -80,6 +93,10 @@ export function encodeArgument(
       return value;
 
     case PrimitiveType.DataSignature:
+      if (typeof value === 'string' && value.startsWith('0x')) {
+        value = Buffer.from(value.slice(2), 'hex');
+      }
+      
       if (!Buffer.isBuffer(value)) {
         throw new TypeError(typeof value, typeStr);
       }

--- a/packages/ionio/test/e2e/checkSigFromStack.test.ts
+++ b/packages/ionio/test/e2e/checkSigFromStack.test.ts
@@ -15,12 +15,9 @@ describe('CheckSigFromStack', () => {
     contract = new Contract(
       artifact,
       [
-        Buffer.from('68656c6c6f', 'hex'),
-        Buffer.from('f09f8c8e', 'hex'),
-        Buffer.from(
-          '25d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517',
-          'hex'
-        ),
+        '0x68656c6c6f',
+        '0xf09f8c8e',
+        '0x25d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517',
       ],
       network,
       ecc
@@ -43,10 +40,7 @@ describe('CheckSigFromStack', () => {
       const amount = 9900;
       const feeAmount = 100;
 
-      const datasig = Buffer.from(
-        '22b284224b4e1d4a943d5a911a259b00cc737c19e371eff98dd045e385a8e8d4c24137188c07add25ccf0f930f36360e2ecf06b4ffeee3a1bd4e2f37911d7c6d',
-        'hex'
-      );
+      const datasig = '0x22b284224b4e1d4a943d5a911a259b00cc737c19e371eff98dd045e385a8e8d4c24137188c07add25ccf0f930f36360e2ecf06b4ffeee3a1bd4e2f37911d7c6d';
 
       // lets instantiate the contract using the funding transacton
       const instance = contract.from(utxo.txid, utxo.vout, prevout);

--- a/packages/ionio/test/e2e/checkSigFromStack.test.ts
+++ b/packages/ionio/test/e2e/checkSigFromStack.test.ts
@@ -40,7 +40,8 @@ describe('CheckSigFromStack', () => {
       const amount = 9900;
       const feeAmount = 100;
 
-      const datasig = '0x22b284224b4e1d4a943d5a911a259b00cc737c19e371eff98dd045e385a8e8d4c24137188c07add25ccf0f930f36360e2ecf06b4ffeee3a1bd4e2f37911d7c6d';
+      const datasig =
+        '0x22b284224b4e1d4a943d5a911a259b00cc737c19e371eff98dd045e385a8e8d4c24137188c07add25ccf0f930f36360e2ecf06b4ffeee3a1bd4e2f37911d7c6d';
 
       // lets instantiate the contract using the funding transacton
       const instance = contract.from(utxo.txid, utxo.vout, prevout);

--- a/packages/ionio/test/e2e/transferWithKey.test.ts
+++ b/packages/ionio/test/e2e/transferWithKey.test.ts
@@ -17,7 +17,9 @@ describe('TransferWithKey', () => {
     const artifact: Artifact = require('../fixtures/transfer_with_key.json');
     contract = new Contract(
       artifact,
-      [alicePk.publicKey.slice(1)],
+      [
+        `0x${alicePk.publicKey.slice(1).toString('hex')}`
+      ],
       network,
       ecc
     );

--- a/packages/ionio/test/e2e/transferWithKey.test.ts
+++ b/packages/ionio/test/e2e/transferWithKey.test.ts
@@ -17,9 +17,7 @@ describe('TransferWithKey', () => {
     const artifact: Artifact = require('../fixtures/transfer_with_key.json');
     contract = new Contract(
       artifact,
-      [
-        `0x${alicePk.publicKey.slice(1).toString('hex')}`
-      ],
+      [`0x${alicePk.publicKey.slice(1).toString('hex')}`],
       network,
       ecc
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4704,10 +4704,10 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
-ldk@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/ldk/-/ldk-0.5.1.tgz#026ca6ccde796a3e7f47e172fe07b84f3b0c6170"
-  integrity sha512-0LJwZDDviDT16kEYTO0XPC3h+H26z5EmKEV07N0Dpck7/A98+lOzeTTiSuBQR7C7CI24XQgIw+rPgHVV0x3ETw==
+ldk@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ldk/-/ldk-0.5.2.tgz#99231d86d6179f0f515946d8ddff9ef9e5cb5973"
+  integrity sha512-lqUqACdbAvyzmA4SUtnyMuFG14PpInD3Ymxuyhi9wwKRnxRmIJDQ4wxwoC1gw/qYiNR8Qqc7XvcfAPyDgcY8cw==
   dependencies:
     axios "^0.21.1"
     bip32 "^3.0.1"


### PR DESCRIPTION
This is helpful for integrating Ionio in string-based environment (such as Browser extension web providers using message passing to communicate between content script and background script)