### PR TITLE
Inject zkplib to the Contract class

### DIFF
--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -46,6 +46,7 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^7.0.8",
+    "@vulpemventures/secp256k1-zkp": "^2.1.1",
     "axios": "^0.27.2",
     "bip32": "^3.0.1",
     "husky": "^8.0.1",
@@ -58,7 +59,7 @@
   },
   "dependencies": {
     "ldk": "^0.5.8",
-    "liquidjs-lib": "^6.0.2-liquid.18"
+    "liquidjs-lib": "^6.0.2-liquid.19"
   },
   "jest": {
     "testTimeout": 15000

--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "ldk": "^0.5.8",
-    "liquidjs-lib": "^6.0.2-liquid.17"
+    "liquidjs-lib": "https://github.com/tiero/liquidjs-lib-1#export-confidential"
   },
   "jest": {
     "testTimeout": 15000

--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "ldk": "^0.5.8",
-    "liquidjs-lib": "https://github.com/tiero/liquidjs-lib-1#export-confidential"
+    "liquidjs-lib": "^6.0.2-liquid.18"
   },
   "jest": {
     "testTimeout": 15000

--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -30,7 +30,7 @@ import {
   isConfidentialOutput,
 } from 'ldk';
 import { TapLeafScript } from 'liquidjs-lib/src/psetv2/interfaces';
-import secp256k1 from '@vulpemventures/secp256k1-zkp';
+import { ZKPInterface } from 'liquidjs-lib/src/confidential';
 
 export interface TransactionInterface {
   pset: Pset;
@@ -71,7 +71,8 @@ export class Transaction implements TransactionInterface {
     unblindDataFundingUtxo: confidential.UnblindOutputResult | undefined,
     private taprootData: TaprootData,
     private network: networks.Network,
-    private ecclib: bip341.TinySecp256k1Interface
+    private ecclib: bip341.TinySecp256k1Interface,
+    private zkplib: ZKPInterface
   ) {
     this.pset = Creator.newPset();
 
@@ -328,12 +329,11 @@ export class Transaction implements TransactionInterface {
           'if one confidential input is spent, at least one of the outputs must be blinded'
         );
 
-      const zkpLib = await secp256k1();
       const zkpGenerator = new ZKPGenerator(
-        zkpLib,
+        this.zkplib,
         ZKPGenerator.WithOwnedInputs(this.unblindedInputs)
       );
-      const zkpValidator = new ZKPValidator(zkpLib);
+      const zkpValidator = new ZKPValidator(this.zkplib);
       const outputBlindingArgs = zkpGenerator.blindOutputs(
         this.pset,
         Pset.ECCKeysGenerator(this.ecclib)

--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -15,6 +15,7 @@ import {
   witnessStackToScriptWitness,
   ZKPGenerator,
   ZKPValidator,
+  TapLeafScript,
 } from 'liquidjs-lib';
 import { Argument, encodeArgument } from './Argument';
 import { ArtifactFunction, Parameter } from './Artifact';
@@ -29,8 +30,6 @@ import {
   UnblindedOutput,
   isConfidentialOutput,
 } from 'ldk';
-import { TapLeafScript } from 'liquidjs-lib/src/psetv2/interfaces';
-import { ZKPInterface } from 'liquidjs-lib/src/confidential';
 
 export interface TransactionInterface {
   pset: Pset;
@@ -72,7 +71,7 @@ export class Transaction implements TransactionInterface {
     private taprootData: TaprootData,
     private network: networks.Network,
     private ecclib: bip341.TinySecp256k1Interface,
-    private zkplib: ZKPInterface
+    private zkplib: confidential.ZKPInterface,
   ) {
     this.pset = Creator.newPset();
 

--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -71,7 +71,7 @@ export class Transaction implements TransactionInterface {
     private taprootData: TaprootData,
     private network: networks.Network,
     private ecclib: bip341.TinySecp256k1Interface,
-    private zkplib: confidential.ZKPInterface,
+    private zkplib: confidential.ZKPInterface
   ) {
     this.pset = Creator.newPset();
 

--- a/packages/ionio/test/e2e/calculator.test.ts
+++ b/packages/ionio/test/e2e/calculator.test.ts
@@ -1,5 +1,7 @@
-import { Contract } from '../../src';
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+
+import { Contract } from '../../src';
 import { bob, network } from '../fixtures/vars';
 import { payments, TxOutput } from 'liquidjs-lib';
 import { broadcast, faucetComplex } from '../utils';
@@ -10,9 +12,10 @@ describe('Calculator', () => {
   let utxo: { txid: string; vout: number; value: number; asset: string };
 
   beforeAll(async () => {
+    const zkp = await secp256k1();
     // eslint-disable-next-line global-require
     const artifact = require('../fixtures/calculator.json');
-    contract = new Contract(artifact, [3], network, ecc);
+    contract = new Contract(artifact, [3], network, { ecc, zkp });
     const response = await faucetComplex(contract.address, 0.0001);
 
     prevout = response.prevout;

--- a/packages/ionio/test/e2e/checkSigFromStack.test.ts
+++ b/packages/ionio/test/e2e/checkSigFromStack.test.ts
@@ -1,5 +1,7 @@
-import { Contract } from '../../src';
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+
+import { Contract } from '../../src';
 import { bob, network } from '../fixtures/vars';
 import { broadcast, faucetComplex } from '../utils';
 import { payments, TxOutput } from 'liquidjs-lib';
@@ -10,6 +12,7 @@ describe('CheckSigFromStack', () => {
   let utxo: { txid: string; vout: number; value: number; asset: string };
 
   beforeAll(async () => {
+    const zkp = await secp256k1();
     // eslint-disable-next-line global-require
     const artifact = require('../fixtures/checksigfromstack.json');
     contract = new Contract(
@@ -20,7 +23,7 @@ describe('CheckSigFromStack', () => {
         '0x25d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517',
       ],
       network,
-      ecc
+      { ecc, zkp }
     );
 
     const response = await faucetComplex(contract.address, 0.0001);

--- a/packages/ionio/test/e2e/singleHopVault.test.ts
+++ b/packages/ionio/test/e2e/singleHopVault.test.ts
@@ -1,5 +1,7 @@
-import { Contract } from '../../src';
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+
+import { Contract } from '../../src';
 import { alicePk, network } from '../fixtures/vars';
 import { address, payments, TxOutput } from 'liquidjs-lib';
 import { broadcast, faucetComplex } from '../utils';
@@ -23,13 +25,14 @@ describe('SingleHopVault', () => {
     .address!;
 
   beforeEach(async () => {
+    const zkp = await secp256k1();
     // eslint-disable-next-line global-require
     const artifact: Artifact = require('../fixtures/single_hop_vault.json');
     contract = new Contract(
       artifact,
       [coldScriptProgram, hotScriptProgram, sats - fee, network.assetHash, 2],
       network,
-      ecc
+      { ecc, zkp }
     );
     const response = await faucetComplex(contract.address, sats / 10 ** 8);
 

--- a/packages/ionio/test/e2e/syntheticAsset.test.ts
+++ b/packages/ionio/test/e2e/syntheticAsset.test.ts
@@ -1,5 +1,7 @@
-import { Contract, Signer } from '../../src';
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+
+import { Contract, Signer } from '../../src';
 import { ECPairInterface } from 'ecpair';
 import { alicePk, bobPk, oraclePk, network } from '../fixtures/vars';
 import {
@@ -83,6 +85,7 @@ describe('SyntheticAsset', () => {
 
   beforeEach(async () => {
     try {
+      const zkp = await secp256k1();
       const artifact = require('../fixtures/synthetic_asset.json');
       contract = new Contract(
         artifact,
@@ -103,7 +106,7 @@ describe('SyntheticAsset', () => {
           timestampBytes,
         ],
         network,
-        ecc
+        { ecc, zkp }
       );
     } catch (e) {
       console.error(e);

--- a/packages/ionio/test/e2e/transferWithKey.test.ts
+++ b/packages/ionio/test/e2e/transferWithKey.test.ts
@@ -1,5 +1,7 @@
-import { Contract } from '../../src';
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+
+import { Contract } from '../../src';
 import { alicePk, network } from '../fixtures/vars';
 import { payments, TxOutput } from 'liquidjs-lib';
 import { broadcast, faucetComplex, getSignerWithECPair } from '../utils';
@@ -14,13 +16,17 @@ describe('TransferWithKey', () => {
   const signer: Signer = getSignerWithECPair(alicePk, network);
 
   beforeAll(async () => {
+    const zkp = await secp256k1();
     // eslint-disable-next-line global-require
     const artifact: Artifact = require('../fixtures/transfer_with_key.json');
     contract = new Contract(
       artifact,
       [`0x${alicePk.publicKey.slice(1).toString('hex')}`],
       network,
-      ecc
+      {
+        ecc,
+        zkp,
+      }
     );
 
     /**

--- a/website/blog/2022-09-01-ionio-calculator.md
+++ b/website/blog/2022-09-01-ionio-calculator.md
@@ -140,12 +140,14 @@ yarn add liquidjs-lib-taproot
 4. Add script section on top
 
 ```ts
-<script type="ts">
+<script type="ts" async>
   import { Artifact, Contract } from '@ionio-lang/ionio';
   import { networks, address, confidential, AssetHash } from 'liquidjs-lib';
   import * as ecc from 'tiny-secp256k1';
   import artifact from './calculator.json';
 
+  // instantiate the secp256-zkp wasm library
+  const zkp = await secp256k1();
   // define the network we going to work
   const network = networks.regtest;
   // create empty state
@@ -164,8 +166,8 @@ yarn add liquidjs-lib-taproot
     [3], 
     // network for address encoding
     network, 
-    // injectable secp256k1 library 
-    ecc 
+    // injectable secp256k1 libraries 
+    { ecc, zkp } 
   );
   const contractAddress = contract.address;
 </script>

--- a/website/docs/SDK/instantiation.md
+++ b/website/docs/SDK/instantiation.md
@@ -18,7 +18,7 @@ new Contract(
 )
 ```
 
-A Ionio contract can be instantiated by providing an `Artifact` object, the list of hardcoded arguments `Argument[]`, a `Network` and a `TinySecp256k1Interface`.
+A Ionio contract can be instantiated by providing an `Artifact` object, the list of hardcoded arguments `Argument[]`, a `Network`, a `TinySecp256k1Interface` and a `ZKPInterface`
 
 An `Artifact` object is the result of compiling a Ionio contract with Ionio compiler. Compilation ~~can~~ will be done using the standalone `ionioc` CLI or programmatically with the `ionioc` NPM package.
 
@@ -27,7 +27,9 @@ An `Artifact` object is the result of compiling a Ionio contract with Ionio comp
 ```ts
 import { Contract, networks } from '@ionio-lang/ionio';
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
 
+const zkp = await secp256k1();
 
 const artifact = {
   "contractName": "Calculator",
@@ -61,7 +63,7 @@ const artifact = {
 };
 
 
-const contract = new Contract(artifact, [3], networks.regtest, ecc);
+const contract = new Contract(artifact, [3], networks.regtest, { ecc, zkp });
 ```
 
 ### address
@@ -100,12 +102,14 @@ These contract functions return an incomplete `Transaction` object, which needs 
 #### Example
 ```ts
 import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
 import { Contract, networks } from '@ionio-lang/ionio';
 import { artifact, myself, to, amount, fundingUtxo, prevout, broadcast } from './somewhere';
+const zkp = await secp256k1();
 
 const feeAmount = 100;
 
-const contract = new Contract(artifact, [3], networks.regtest, ecc);
+const contract = new Contract(artifact, [3], networks.regtest, { ecc, zkp });
 
 // attach to the funded contract using the utxo
 const instance = contract.from(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4700,13 +4700,14 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-liquidjs-lib@^6.0.2-liquid.17:
-  version "6.0.2-liquid.17"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.17.tgz#815d1f76f9412c111d74eb05b0baef71873c92a3"
-  integrity sha512-1lyM8o9k1niYEwp9arFICmHbT2cbN6SLPmARZQyIBEk4C2XAea+LKsaiUypYDVN+UnBWBo5sNXsMUtFOF+3vlQ==
+liquidjs-lib@^6.0.2-liquid.7:
+  version "6.0.2-liquid.12"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.12.tgz#ab3627894cc58675bfec5efb39f7b39cb2f01b05"
+  integrity sha512-PR583/rX67ztqa2KolXbMn/jDHQUpRc9nSgywyRMQ33ghKxdihu9DRgLtlFXDQ3Nq8ByY4KfcnoAyI4/jT9Upw==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"
+    "@vulpemventures/secp256k1-zkp" vulpemventures/secp256k1-zkp
     axios "^0.21.1"
     bech32 "^2.0.0"
     bip174-liquid "^1.0.3"
@@ -4723,14 +4724,12 @@ liquidjs-lib@^6.0.2-liquid.17:
     varuint-bitcoin "^1.1.2"
     wif "^2.0.1"
 
-liquidjs-lib@^6.0.2-liquid.7:
-  version "6.0.2-liquid.12"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.12.tgz#ab3627894cc58675bfec5efb39f7b39cb2f01b05"
-  integrity sha512-PR583/rX67ztqa2KolXbMn/jDHQUpRc9nSgywyRMQ33ghKxdihu9DRgLtlFXDQ3Nq8ByY4KfcnoAyI4/jT9Upw==
+"liquidjs-lib@https://github.com/tiero/liquidjs-lib-1#export-confidential":
+  version "6.0.2-liquid.17"
+  resolved "https://github.com/tiero/liquidjs-lib-1#3c9991a009890192edd0ba97f6c4b934ed9f1346"
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"
-    "@vulpemventures/secp256k1-zkp" vulpemventures/secp256k1-zkp
     axios "^0.21.1"
     bech32 "^2.0.0"
     bip174-liquid "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,14 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@vulpemventures/secp256k1-zkp@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@vulpemventures/secp256k1-zkp/-/secp256k1-zkp-2.1.1.tgz#723692d666df2294a691c1de38b12891e48e1e16"
+  integrity sha512-OIfvP0kRC38Ab8C2MMibKlPVY/PmT81uNGZrCxK24INLh5PPUqOcdK2VvK+xpCvh8TjAsZrwT3KdN6N9fqsTZQ==
+  dependencies:
+    "@types/node" "^13.9.2"
+    long "^4.0.0"
+
 "@vulpemventures/secp256k1-zkp@vulpemventures/secp256k1-zkp":
   version "2.1.0"
   resolved "https://codeload.github.com/vulpemventures/secp256k1-zkp/tar.gz/a515ce1d910a8bc4785a0b20d9e0630d3e808751"
@@ -4700,10 +4708,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-liquidjs-lib@^6.0.2-liquid.18:
-  version "6.0.2-liquid.18"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.18.tgz#45bfbedda4bdfadc7d42020129112b4fde62bd9b"
-  integrity sha512-06g4EYTmTa0A0JENVxS7Ynh2mFfIPagApmzBFKoqHFqOh9Is+zDM/o/a9uaiV3IuhoyEllCyxufaufU3Dn8XCA==
+liquidjs-lib@^6.0.2-liquid.19:
+  version "6.0.2-liquid.19"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.19.tgz#c92d613e5061c1d94fa1ff8184ba7e2bdaff33b4"
+  integrity sha512-v8Xjbef/fHQ6mX/mq0i5cbyF1bbYPwcKne4tO/ZrYz5xmdeX9HT6aNwposg1rdYpS6ShjNV5C2OPy8bfjjNmOg==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4700,14 +4700,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-liquidjs-lib@^6.0.2-liquid.7:
-  version "6.0.2-liquid.12"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.12.tgz#ab3627894cc58675bfec5efb39f7b39cb2f01b05"
-  integrity sha512-PR583/rX67ztqa2KolXbMn/jDHQUpRc9nSgywyRMQ33ghKxdihu9DRgLtlFXDQ3Nq8ByY4KfcnoAyI4/jT9Upw==
+liquidjs-lib@^6.0.2-liquid.18:
+  version "6.0.2-liquid.18"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.18.tgz#45bfbedda4bdfadc7d42020129112b4fde62bd9b"
+  integrity sha512-06g4EYTmTa0A0JENVxS7Ynh2mFfIPagApmzBFKoqHFqOh9Is+zDM/o/a9uaiV3IuhoyEllCyxufaufU3Dn8XCA==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"
-    "@vulpemventures/secp256k1-zkp" vulpemventures/secp256k1-zkp
     axios "^0.21.1"
     bech32 "^2.0.0"
     bip174-liquid "^1.0.3"
@@ -4724,12 +4723,14 @@ liquidjs-lib@^6.0.2-liquid.7:
     varuint-bitcoin "^1.1.2"
     wif "^2.0.1"
 
-"liquidjs-lib@https://github.com/tiero/liquidjs-lib-1#export-confidential":
-  version "6.0.2-liquid.17"
-  resolved "https://github.com/tiero/liquidjs-lib-1#3c9991a009890192edd0ba97f6c4b934ed9f1346"
+liquidjs-lib@^6.0.2-liquid.7:
+  version "6.0.2-liquid.12"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.12.tgz#ab3627894cc58675bfec5efb39f7b39cb2f01b05"
+  integrity sha512-PR583/rX67ztqa2KolXbMn/jDHQUpRc9nSgywyRMQ33ghKxdihu9DRgLtlFXDQ3Nq8ByY4KfcnoAyI4/jT9Upw==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"
+    "@vulpemventures/secp256k1-zkp" vulpemventures/secp256k1-zkp
     axios "^0.21.1"
     bech32 "^2.0.0"
     bip174-liquid "^1.0.3"


### PR DESCRIPTION
This changes the interface of the `Contract` class to accept an object `{ ecc: bip341.TinySecp256k1Interface; zkp: ZKPInterface; }` and makes possible to inject also the zkp library

