### PR TITLE
when conf & unconf same tx cant blind outputs

### DIFF
--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "liquidjs-lib": "^6.0.2-liquid.22"
+    "liquidjs-lib": "^6.0.2-liquid.23"
   },
   "jest": {
     "testTimeout": 15000

--- a/packages/ionio/package.json
+++ b/packages/ionio/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "liquidjs-lib": "^6.0.2-liquid.21"
+    "liquidjs-lib": "^6.0.2-liquid.22"
   },
   "jest": {
     "testTimeout": 15000

--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -200,7 +200,7 @@ export class Transaction implements TransactionInterface {
     assetID: string = this.network.assetHash,
     hexChunks: string[] = [],
     blindingPublicKeyHex?: string,
-    blinderIndex: number = 0
+    blinderIndex: number | undefined = undefined
   ): this {
     const opRetScript = script.compile([
       script.OPS.OP_RETURN,

--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -52,9 +52,9 @@ export interface TaprootData {
 
 export class Transaction implements TransactionInterface {
   public pset: Pset;
+  public unblindedInputs: OwnedInput[] = [] as any;
 
   private fundingUtxoIndex: number = 0;
-  private unblindedInputs: OwnedInput[] = [] as any;
 
   constructor(
     private constructorInputs: Parameter[],

--- a/packages/ionio/test/e2e/syntheticAsset.test.ts
+++ b/packages/ionio/test/e2e/syntheticAsset.test.ts
@@ -134,7 +134,7 @@ describe('SyntheticAsset', () => {
     );
   });
 
-  it.only('should redeem with burnt output', async () => {
+  it('should redeem with burnt output', async () => {
     const tx = instance.functions
       .redeem(borrowerSigner)
       // spend an asset
@@ -171,7 +171,7 @@ describe('SyntheticAsset', () => {
     expect(txid).toBeDefined();
   });
 
-  it('should topup burning & reissuing', async () => {
+  it.only('should topup burning & reissuing', async () => {
     const newCollateralCoinAmount = 500000;
     const newCollateralCoin = await faucetComplex(
       borrower.confidentialAddress!,

--- a/packages/ionio/test/fixtures/synthetic_asset.json
+++ b/packages/ionio/test/fixtures/synthetic_asset.json
@@ -6,15 +6,7 @@
       "type": "asset"
     },
     {
-      "name": "collateralAsset",
-      "type": "asset"
-    },
-    {
       "name": "borrowAmount",
-      "type": "value"
-    },
-    {
-      "name": "payoutAmount",
       "type": "value"
     },
     {
@@ -28,10 +20,6 @@
     {
       "name": "issuerPk",
       "type": "xonlypubkey"
-    },
-    {
-      "name": "issuerScriptProgram",
-      "type": "bytes"
     },
     {
       "name": "priceLevel",
@@ -64,19 +52,6 @@
             "asset": "$borrowAsset",
             "nonce": ""
           }
-        },
-        {
-          "type": "output",
-          "atIndex": 1,
-          "expected": {
-            "script" : {
-              "version": 0,
-              "program": "$issuerScriptProgram"
-            },
-            "value": "$payoutAmount",
-            "asset": "$collateralAsset",
-            "nonce": ""
-          }
         }
       ],
       "asm":[
@@ -103,33 +78,6 @@
         "OP_EQUALVERIFY",
 
         "OP_0",
-        "OP_INSPECTOUTPUTNONCE",
-        "OP_0",
-        "OP_EQUALVERIFY",
-
-
-        "OP_1",
-        "OP_INSPECTOUTPUTASSET",
-        "OP_1",
-        "OP_EQUALVERIFY",
-        "$collateralAsset",
-        "OP_EQUALVERIFY",
-
-        "OP_1",
-        "OP_INSPECTOUTPUTVALUE",
-        "OP_1",
-        "OP_EQUALVERIFY",
-        "$payoutAmount",
-        "OP_EQUALVERIFY",
-
-        "OP_1",
-        "OP_INSPECTOUTPUTSCRIPTPUBKEY",
-        "OP_0",
-        "OP_EQUALVERIFY",
-        "$issuerScriptProgram",
-        "OP_EQUALVERIFY",
-
-        "OP_1",
         "OP_INSPECTOUTPUTNONCE",
         "OP_0",
         "OP_EQUALVERIFY",
@@ -218,68 +166,6 @@
 
 
         "$issuerPk",
-        "OP_CHECKSIG"
-      ]
-    },
-    {
-      "name": "topup",
-      "functionInputs": [
-        {
-          "name": "issuerSig",
-          "type": "sig"
-        },
-        {
-          "name": "borrowerSig",
-          "type": "sig"
-        }
-      ],
-      "require": [
-        {
-          "type": "output",
-          "atIndex": 0,
-          "expected": {
-            "script" : {
-              "version": -1,
-              "program": "0x6a"
-            },
-            "value": "$borrowAmount",
-            "asset": "$borrowAsset",
-            "nonce": ""
-          }
-        }
-      ],
-      "asm": [
-        "OP_0",
-        "OP_INSPECTOUTPUTASSET",
-        "OP_1",
-        "OP_EQUALVERIFY",
-        "$borrowAsset",
-        "OP_EQUALVERIFY",
-
-        "OP_0",
-        "OP_INSPECTOUTPUTVALUE",
-        "OP_1",
-        "OP_EQUALVERIFY",
-        "$borrowAmount",
-        "OP_EQUALVERIFY",
-      
-        "OP_0",
-        "OP_INSPECTOUTPUTSCRIPTPUBKEY",
-        "OP_1NEGATE",
-        "OP_EQUALVERIFY",
-        "0x6a",
-        "OP_SHA256",
-        "OP_EQUALVERIFY",
-
-        "OP_0",
-        "OP_INSPECTOUTPUTNONCE",
-        "OP_0",
-        "OP_EQUALVERIFY",
-
-        "$issuerPk",
-        "OP_CHECKSIGVERIFY",
-
-        "$borrowerPk",
         "OP_CHECKSIG"
       ]
     }

--- a/packages/ionio/test/unit/transformer.test.ts
+++ b/packages/ionio/test/unit/transformer.test.ts
@@ -23,15 +23,10 @@ describe('transformArtifact', () => {
       AssetHash.fromHex(
         '5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225'
       ).hex,
-      AssetHash.fromHex(
-        '5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225'
-      ).hex,
       templateString('borrowAmount2'),
-      templateString('payoutAmount2'),
       templateString('borrowePk'),
       templateString('oraclePk'),
-      templateString('payoutPk'),
-      templateString('issuerScriptProgram'),
+      templateString('issuerPk'),
       templateString('priceLevel'),
       templateString('setupTimestamp'),
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,10 +4672,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-liquidjs-lib@^6.0.2-liquid.21:
-  version "6.0.2-liquid.21"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.21.tgz#2ec8285269acf613e8973cb8faaeaf4551f841aa"
-  integrity sha512-pnc/umuJLYHcFN59SgKTr05KOthi+rumyZMbViT5fLMJ9APTqEQXMeZT+S0k/mP2FUPKIqLuRz1pUiUOV+rnJA==
+liquidjs-lib@^6.0.2-liquid.22:
+  version "6.0.2-liquid.22"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.22.tgz#c1812f3d102a01536af9c296d7411fe2971c7d78"
+  integrity sha512-8BG43c7nlc65eNfLxOTc99PMgINS1eSCXm8QfbRl+TikPJ9pS0AbiX5f9+kjLRRa5uAtcDS9rJrn1eAgvpKxGQ==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,10 +4672,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-liquidjs-lib@^6.0.2-liquid.22:
-  version "6.0.2-liquid.22"
-  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.22.tgz#c1812f3d102a01536af9c296d7411fe2971c7d78"
-  integrity sha512-8BG43c7nlc65eNfLxOTc99PMgINS1eSCXm8QfbRl+TikPJ9pS0AbiX5f9+kjLRRa5uAtcDS9rJrn1eAgvpKxGQ==
+liquidjs-lib@^6.0.2-liquid.23:
+  version "6.0.2-liquid.23"
+  resolved "https://registry.yarnpkg.com/liquidjs-lib/-/liquidjs-lib-6.0.2-liquid.23.tgz#5bd8f132410e8bf1775726d78a2bde132ba405cd"
+  integrity sha512-LaHjE+n7va0CkQYCzp1OgKYTTrT4MH4wVGARBLm/oDHAWtZCGE65c9/wzkmUhqFUMd3xSnWqLHKlWD7NFMOjdg==
   dependencies:
     "@types/randombytes" "^2.0.0"
     "@types/wif" "^2.0.2"


### PR DESCRIPTION

## How to replicate 

```sh
yarn test ./test/e2e/syntheticAsset.test.ts
```

It fails with `TypeError: key must be a Buffer of 32 bytes`


basically what happens is that inside `maybeUnblindInUtxos` triggered by `blindOutputs` when an input is uncofidential the asset being pushed is 33 bytes instead of 32 (ie. prefix still on),

Any reason why we do not strip the prefix? @louisinger @altafan 
 

From https://github.com/vulpemventures/liquidjs-lib/blob/master/ts_src/psetv2/zkp.ts#L536-L554

```js
if (this.ownedInputs && this.ownedInputs.length > 0) {
      return pset.inputs.map((input, i) => {
        const ownedInput = this.ownedInputs.find(({ index }) => index === i);
        if (ownedInput) {
          console.log('ownedInput at index ' + i, ownedInput);
          return {
            value: '',
            valueBlindingFactor: Buffer.from([]),
            asset: ownedInput.asset,
            assetBlindingFactor: ownedInput.assetBlindingFactor,
          };
        }
        console.log('non blinded input at index ' + i, input.getUtxo().asset.length)
        return {
          value: '',
          valueBlindingFactor: Buffer.from([]),
          asset: input.getUtxo().asset,
          assetBlindingFactor: transaction_1.ZERO,
        };
      });
    }
```