### PR TITLE
add support for uint64 as primitive type

### DIFF
--- a/packages/ionio/src/Argument.ts
+++ b/packages/ionio/src/Argument.ts
@@ -1,4 +1,5 @@
 import { ElementsValue, script } from 'liquidjs-lib';
+import { writeUInt64LE } from 'liquidjs-lib/src/bufferutils';
 import { isSigner, Signer } from './Signer';
 
 export type Argument = number | boolean | string | Buffer | Signer;
@@ -13,6 +14,7 @@ export enum PrimitiveType {
   DataSignature = 'datasig',
   PublicKey = 'pubkey',
   XOnlyPublicKey = 'xonlypubkey',
+  UInt64 = 'uint64',
 }
 
 export function encodeArgument(
@@ -32,10 +34,19 @@ export function encodeArgument(
       return value;
 
     case PrimitiveType.Number:
-      if (typeof value !== 'number') {
+      if (typeof value !== 'number')
         throw new TypeError(typeof value, typeStr);
-      }
+
       return script.number.encode(value);
+
+    case PrimitiveType.UInt64:
+      if (typeof value !== 'number')
+        throw new TypeError(typeof value, typeStr);
+
+      const buffer = Buffer.alloc(8);
+      writeUInt64LE(buffer, value as number, 0);
+
+      return buffer;
 
     case PrimitiveType.XOnlyPublicKey:
       if (typeof value === 'string' && value.startsWith('0x')) {
@@ -62,6 +73,7 @@ export function encodeArgument(
         throw new Error('Invalid public key length');
       }
       return value;
+
 
     case PrimitiveType.Boolean:
       if (typeof value !== 'boolean') {

--- a/packages/ionio/src/Argument.ts
+++ b/packages/ionio/src/Argument.ts
@@ -34,14 +34,12 @@ export function encodeArgument(
       return value;
 
     case PrimitiveType.Number:
-      if (typeof value !== 'number')
-        throw new TypeError(typeof value, typeStr);
+      if (typeof value !== 'number') throw new TypeError(typeof value, typeStr);
 
       return script.number.encode(value);
 
     case PrimitiveType.UInt64:
-      if (typeof value !== 'number')
-        throw new TypeError(typeof value, typeStr);
+      if (typeof value !== 'number') throw new TypeError(typeof value, typeStr);
 
       const buffer = Buffer.alloc(8);
       writeUInt64LE(buffer, value as number, 0);
@@ -73,7 +71,6 @@ export function encodeArgument(
         throw new Error('Invalid public key length');
       }
       return value;
-
 
     case PrimitiveType.Boolean:
       if (typeof value !== 'boolean') {

--- a/packages/ionio/test/e2e/spendLimit.test.ts
+++ b/packages/ionio/test/e2e/spendLimit.test.ts
@@ -1,0 +1,78 @@
+import * as ecc from 'tiny-secp256k1';
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+
+import { Contract } from '../../src';
+import { alicePk, network } from '../fixtures/vars';
+import { payments, TxOutput } from 'liquidjs-lib';
+import { broadcast, faucetComplex } from '../utils';
+import { Artifact } from '../../src/Artifact';
+
+describe('SpendLimit', () => {
+  let contract: Contract;
+  let prevout: TxOutput;
+  let utxo: { txid: string; vout: number; value: number; asset: string };
+
+  beforeEach(async () => {
+    const zkp = await secp256k1();
+    // eslint-disable-next-line global-require
+    const artifact: Artifact = require('../fixtures/spend_limit.json');
+    contract = new Contract(artifact, [5000], network, { ecc, zkp });
+
+    const response = await faucetComplex(
+      contract.address,
+      0.0001,
+      network.assetHash
+    );
+
+    prevout = response.prevout;
+    utxo = response.utxo;
+  });
+
+  describe('spendLessThanLimit', () => {
+    it('should spend if passed amount < limit', async () => {
+      const to = payments.p2wpkh({ pubkey: alicePk.publicKey }).address!;
+      const amount = 3000;
+      const feeAmount = 100;
+
+      // lets instantiare the contract using the funding transacton
+      const instance = contract.from(
+        utxo.txid,
+        utxo.vout,
+        prevout
+      );
+
+      const tx = instance.functions
+        .spendLessThanLimit(amount)
+        .withRecipient(to, amount, network.assetHash)
+        .withRecipient(contract.address, 10000 - amount - feeAmount, network.assetHash)
+        .withFeeOutput(feeAmount);
+
+      const signedTx = await tx.unlock();
+      const hex = signedTx.toHex();
+      const txid = await broadcast(hex);
+      expect(txid).toBeDefined();
+    });
+
+    it('should NOT spend if passed amount > limit', async () => {
+      const to = payments.p2wpkh({ pubkey: alicePk.publicKey }).address!;
+      const feeAmount = 100;
+      const amount = 10000 - feeAmount;
+
+      // lets instantiare the contract using the funding transacton
+      const instance = contract.from(
+        utxo.txid,
+        utxo.vout,
+        prevout
+      );
+
+      const tx = instance.functions
+        .spendLessThanLimit(amount)
+        .withRecipient(to, amount, network.assetHash)
+        .withFeeOutput(feeAmount);
+
+      const signedTx = await tx.unlock();
+      const hex = signedTx.toHex();
+      await expect(broadcast(hex, false)).rejects.toThrow();
+    });
+  });
+});

--- a/packages/ionio/test/e2e/spendLimit.test.ts
+++ b/packages/ionio/test/e2e/spendLimit.test.ts
@@ -35,16 +35,16 @@ describe('SpendLimit', () => {
       const feeAmount = 100;
 
       // lets instantiare the contract using the funding transacton
-      const instance = contract.from(
-        utxo.txid,
-        utxo.vout,
-        prevout
-      );
+      const instance = contract.from(utxo.txid, utxo.vout, prevout);
 
       const tx = instance.functions
         .spendLessThanLimit(amount)
         .withRecipient(to, amount, network.assetHash)
-        .withRecipient(contract.address, 10000 - amount - feeAmount, network.assetHash)
+        .withRecipient(
+          contract.address,
+          10000 - amount - feeAmount,
+          network.assetHash
+        )
         .withFeeOutput(feeAmount);
 
       const signedTx = await tx.unlock();
@@ -59,11 +59,7 @@ describe('SpendLimit', () => {
       const amount = 10000 - feeAmount;
 
       // lets instantiare the contract using the funding transacton
-      const instance = contract.from(
-        utxo.txid,
-        utxo.vout,
-        prevout
-      );
+      const instance = contract.from(utxo.txid, utxo.vout, prevout);
 
       const tx = instance.functions
         .spendLessThanLimit(amount)

--- a/packages/ionio/test/fixtures/spend_limit.json
+++ b/packages/ionio/test/fixtures/spend_limit.json
@@ -1,0 +1,25 @@
+{
+  "contractName": "spendLimit",
+  "constructorInputs": [
+    {
+      "name": "limit",
+      "type": "uint64"
+    }
+  ],
+  "functions": [
+    {
+      "name": "spendLessThanLimit",
+      "functionInputs": [
+        {
+          "name": "amount",
+          "type": "uint64"
+        }
+      ],
+      "require": [],
+      "asm":[
+        "$limit",
+        "OP_LESSTHAN64"
+      ]
+    }
+  ]
+}

--- a/packages/ionio/test/unit/contract.test.ts
+++ b/packages/ionio/test/unit/contract.test.ts
@@ -2,20 +2,30 @@ import * as ecc from 'tiny-secp256k1';
 import secp256k1 from '@vulpemventures/secp256k1-zkp';
 
 import { alicePk, network } from '../fixtures/vars';
-import { Contract } from '../../src';
+import { Contract, encodeArgument, PrimitiveType } from '../../src';
+import { ZKPInterface } from 'liquidjs-lib/src/confidential';
 
 const transferWithKey = require('../fixtures/transfer_with_key.json');
 
+
 describe('contract', () => {
+  let zkp: ZKPInterface;
+  beforeAll(async () => {
+    zkp = await secp256k1();
+  });
+
   it('should have contractParams not empty and with the same keys as constructorInputs', async () => {
-    const zkp = await secp256k1();
 
     const pubkey = `0x${alicePk.publicKey.slice(1).toString('hex')}`;
-    const contract = new Contract(transferWithKey, [pubkey], network, {
-      zkp,
-      ecc,
-    });
+    const contract = new Contract(transferWithKey, [pubkey], network, { zkp, ecc});
 
     expect(contract.contractParams['pubKey']).toStrictEqual(pubkey);
+  });
+
+  it('should encode a number of type Uint64 as Buffer of 8 bytes lenght', async () => {
+    // 500 in hex is 0x01f4
+    const amountLE64 = Buffer.from('f401000000000000', 'hex'); 
+    const encoded = encodeArgument(500, PrimitiveType.UInt64);
+    expect(encoded).toStrictEqual(amountLE64);
   });
 });

--- a/packages/ionio/test/unit/contract.test.ts
+++ b/packages/ionio/test/unit/contract.test.ts
@@ -7,7 +7,6 @@ import { ZKPInterface } from 'liquidjs-lib/src/confidential';
 
 const transferWithKey = require('../fixtures/transfer_with_key.json');
 
-
 describe('contract', () => {
   let zkp: ZKPInterface;
   beforeAll(async () => {
@@ -15,16 +14,18 @@ describe('contract', () => {
   });
 
   it('should have contractParams not empty and with the same keys as constructorInputs', async () => {
-
     const pubkey = `0x${alicePk.publicKey.slice(1).toString('hex')}`;
-    const contract = new Contract(transferWithKey, [pubkey], network, { zkp, ecc});
+    const contract = new Contract(transferWithKey, [pubkey], network, {
+      zkp,
+      ecc,
+    });
 
     expect(contract.contractParams['pubKey']).toStrictEqual(pubkey);
   });
 
   it('should encode a number of type Uint64 as Buffer of 8 bytes lenght', async () => {
     // 500 in hex is 0x01f4
-    const amountLE64 = Buffer.from('f401000000000000', 'hex'); 
+    const amountLE64 = Buffer.from('f401000000000000', 'hex');
     const encoded = encodeArgument(500, PrimitiveType.UInt64);
     expect(encoded).toStrictEqual(amountLE64);
   });


### PR DESCRIPTION
## `TL;DR`

- we have a new type `uint64` 💯 You can pass a JavaScript `number` and it will be encoded as LE 64bit Buffer