### PR TITLE
feature: taproot key-path 

### DIFF
--- a/packages/ionio/src/Transaction.ts
+++ b/packages/ionio/src/Transaction.ts
@@ -20,7 +20,7 @@ import {
 } from 'liquidjs-lib';
 import { Argument, encodeArgument } from './Argument';
 import { ArtifactFunction, Parameter } from './Artifact';
-import { H_POINT, LEAF_VERSION_TAPSCRIPT } from './constants';
+import { LEAF_VERSION_TAPSCRIPT } from './constants';
 import { isSigner } from './Signer';
 import { Introspect } from './Introspect';
 import { RequiredOutput, RequirementType, ScriptPubKey } from './Requirement';
@@ -67,7 +67,8 @@ export class Transaction implements TransactionInterface {
     unblindDataFundingUtxo: confidential.UnblindOutputResult | undefined,
     private taprootData: TaprootData,
     private network: networks.Network,
-    private secp256k1: Secp256k1Interface
+    private secp256k1: Secp256k1Interface,
+    internalPublicKey: Buffer
   ) {
     this.pset = Creator.newPset();
 
@@ -81,7 +82,11 @@ export class Transaction implements TransactionInterface {
 
     const parityBit = Buffer.of(leafVersion + this.taprootData.parity);
 
-    const controlBlock = Buffer.concat([parityBit, H_POINT.slice(1), ...path]);
+    const controlBlock = Buffer.concat([
+      parityBit,
+      internalPublicKey.subarray(1),
+      ...path,
+    ]);
 
     let sequence;
     this.artifactFunction.require.forEach(requirement => {

--- a/packages/ionio/src/descriptor.ts
+++ b/packages/ionio/src/descriptor.ts
@@ -1,19 +1,22 @@
 import { Artifact, ArtifactFunction } from './Artifact';
 import { H_POINT } from './constants';
 
-const H_POINT_XONLY_HEX = H_POINT.slice(1).toString('hex');
+const H_POINT_XONLY_HEX = H_POINT.subarray(1).toString('hex');
 
 /**
  * build the marina custom descriptor for a given artifact
  * token "$" are not replaced in the asm string, consider using transformArtifact to replace them
  * @param artifact the artifact to build the descriptor for
  */
-export function toDescriptor(artifact: Artifact) {
+export function toDescriptor(
+  artifact: Artifact,
+  internalPublicKey = H_POINT_XONLY_HEX
+): string {
   const { functions } = artifact;
   const leaves = functions.map(toASMstring);
   const tree = reduceLeaves(leaves);
 
-  return `eltr(${H_POINT_XONLY_HEX}, ${tree})`;
+  return `eltr(${internalPublicKey}, ${tree})`;
 }
 
 function reduceLeaves(array: string[]): string {

--- a/packages/ionio/test/e2e/keypath.test.ts
+++ b/packages/ionio/test/e2e/keypath.test.ts
@@ -1,0 +1,88 @@
+import secp256k1 from '@vulpemventures/secp256k1-zkp';
+import { Contract } from '../../src';
+import {
+  BIP371SigningData,
+  Creator,
+  Extractor,
+  Finalizer,
+  Pset,
+  Signer,
+  Transaction,
+  Updater,
+  networks,
+} from 'liquidjs-lib';
+import { ECPairFactory } from 'ecpair';
+import { faucetComplex } from '../utils';
+import { broadcast } from '../utils';
+
+describe('Contract key-path spend', () => {
+  it('should be able to spend a contract using taproot key-path', async () => {
+    const zkp = await secp256k1();
+    const internalKeyPair = ECPairFactory(zkp.ecc).makeRandom();
+    // eslint-disable-next-line global-require
+    const artifact = require('../fixtures/calculator.json');
+    const contract = new Contract(
+      artifact,
+      [3],
+      networks.regtest,
+      zkp,
+      internalKeyPair.publicKey
+    );
+    const response = await faucetComplex(contract.address, 1);
+    const prevout = response.prevout;
+    const utxo = response.utxo;
+
+    const pset = Creator.newPset();
+
+    const updater = new Updater(pset);
+    updater.addInputs([
+      {
+        txid: utxo.txid,
+        txIndex: utxo.vout,
+        witnessUtxo: prevout,
+        tapInternalKey: contract.internalPublicKey.subarray(1), // Pset expects x-only internal key
+        sighashType: Transaction.SIGHASH_DEFAULT,
+      },
+    ]);
+
+    updater.addOutputs([
+      {
+        asset: utxo.asset,
+        amount: 1_0000_0000 - 500,
+        script: contract.scriptPubKey,
+      },
+      {
+        asset: utxo.asset,
+        amount: 500,
+      },
+    ]);
+
+    const signer = new Signer(pset);
+
+    const preimage = signer.pset.getInputPreimage(
+      0,
+      Transaction.SIGHASH_DEFAULT,
+      networks.regtest.genesisBlockHash
+    );
+
+    const signature = Buffer.from(
+      zkp.ecc.signSchnorr(
+        preimage,
+        contract.tweakInternalKey(internalKeyPair.privateKey!)
+      )
+    );
+
+    const partialSig: BIP371SigningData = {
+      genesisBlockHash: networks.regtest.genesisBlockHash,
+      tapKeySig: signature,
+    };
+
+    signer.addSignature(0, partialSig, Pset.SchnorrSigValidator(zkp.ecc));
+
+    const finalizer = new Finalizer(pset);
+    finalizer.finalize();
+
+    const tx = Extractor.extract(pset);
+    await broadcast(tx.toHex());
+  });
+});

--- a/packages/ionio/test/e2e/syntheticAsset.test.ts
+++ b/packages/ionio/test/e2e/syntheticAsset.test.ts
@@ -114,14 +114,8 @@ describe('SyntheticAsset', () => {
           ecc: {
             ...zkp.ecc,
             xOnlyPointAddTweak: (pubkey: Uint8Array, tweak: Uint8Array) => {
-              try {
-                const tweaked = zkp.ecc.xOnlyPointAddTweak(pubkey, tweak);
-                return tweaked;
-              } catch (e) {
-                console.log(pubkey, tweak);
-                console.log(zkp.ecc.xOnlyPointAddTweak);
-                throw e;
-              }
+              const tweaked = zkp.ecc.xOnlyPointAddTweak(pubkey, tweak);
+              return tweaked;
             },
           },
         }


### PR DESCRIPTION
This PR adds a way to overwrite the default (H_POINT) internal key used by `Contract` to build the taproot script.
* internalPublicKey is a public member in `ContractInterface`.
* new method `tweakInternalKey(prvKey)` using to tweak signing key with the script tree. 
* keypath tested in `keypath.test.ts`.

@tiero please review